### PR TITLE
Update groups.plist kerning group rules

### DIFF
--- a/versions/ufo3/groups.plist.md
+++ b/versions/ufo3/groups.plist.md
@@ -57,6 +57,10 @@ Now, an application wants to apply the kerning for the pair "AT". There are diff
 
 Two kerning values are found: -50 and -100. There is no way to determine which one is correct. This ambiguity is eliminated by requiring that glyphs occur in only one group per kerning side.
 
+#### 5. Glyphs must not appear more than once in a single kerning group.
+
+Having duplicates of a glyph in a single kerning group adds no extra information and is redundant.
+
 ### Example
 
 ```xml


### PR DESCRIPTION
At the top of this file it states that:

> With the exception of the kerning groups defined below, glyphs may be in more than one group and they may appear within the same group more than once.

This statement implies 2 restrictions on kerning groups:

1. That a given glyph may not appear in more than one kerning group on the same side (this is discussed in rule 4 of the kerning rules below).
2. That a given glyph may not appear in the same kerning group more than once.

The second point is not currently explicitly written down as one of the kerning group rules, and I would like to add it there for the following reasons:

* (I believe) It never happens in practice. It wouldn't make sense to mention the same glyph several times in a single kerning group (please correct me if I'm wrong, I'm new here!).
* If it does occur (duplicates of a glyph are put into a single kerning group), our current fontmake pipeline throws a cryptic error. My goal is to intercept it and throw a readable error message instead. After some digging, ufoLib looks like the earliest stage at which it can be done.

It seems to me that this rule may have been omitted due to it being self-evident, however, I want to confirm here that it is correct. I can then go and build in a validation check.